### PR TITLE
Fix setting topic twice (should resolve #32)

### DIFF
--- a/plugins/autotopic.py
+++ b/plugins/autotopic.py
@@ -33,6 +33,7 @@ class autotopic(Plugin):
 
             if old_status != status:
                 irc.topic(BYTEBOT_CHANNEL, unicode(topic).encode('utf-8', errors='replace'))
+                irc.topic(BYTEBOT_CHANNEL)
         except Exception as e:
             print(e)
             print("Error while setting topic")


### PR DESCRIPTION
Reget topic after setting the new topic, so old_topic gets the new topic during the next run. Otherwise topic will not be refreshed early enough because of the asynchronous query. Should resolve #32 
