### PR TITLE
Fixed travis cache variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: false
-cache: bundler
+cache: pip
 
 python:
   - "2.7"


### PR DESCRIPTION
accidentally used ruby instead of python/pip cache